### PR TITLE
al enviar un email se recupera el usuario a partir del mail (fix #3495)

### DIFF
--- a/src/Celsius3/CoreBundle/Controller/AdminEmailRestController.php
+++ b/src/Celsius3/CoreBundle/Controller/AdminEmailRestController.php
@@ -66,14 +66,17 @@ class AdminEmailRestController extends BaseInstanceDependentRestController
         }
         $text = $request->request->get('text');
 
-        $order_id = $request->request->has('order_id') ? $request->request->get('order_id') : -1;
-        $order =  $this->getDoctrine()->getManager()
-                ->getRepository('Celsius3CoreBundle:Order')
-                ->find($order_id);
+        $order_id = $request->request->has('order_id') ? $request->request->get('order_id') : false;
+        $order =  ($order_id)
+                   ? $this->getDoctrine()->getManager()->getRepository('Celsius3CoreBundle:Order')->find($order_id)
+                   : null;
+
+        $user = $this->getDoctrine()->getManager()->getRepository('Celsius3CoreBundle:BaseUser')->findOneBy(array('email'=>$email));
+
 
         $mailManager = $this->get('celsius3_core.mail_manager');
         $text = $mailManager->renderRawTemplate($text,array(
-            'user' => $this->getUser(),
+            'user' => $user,
             'instance' => $this->getInstance(),
             'order' => $order
         ));


### PR DESCRIPTION
ahora se usa el mail como identificador del usuario al que se le está enviando el correo. Siempre se le envía a un usuario registrado?